### PR TITLE
fix: update version to 1.3.1-zendesk

### DIFF
--- a/lib/clamp/version.rb
+++ b/lib/clamp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clamp
-  VERSION = "1.3.1".freeze
+  VERSION = "1.3.1-zendesk".freeze
 end


### PR DESCRIPTION
this allows us to push the custom version to local artifactory. we cannot use git sourced gem in scooter bundler due to bundler bug related to it.

technically the `-zendesk` is defined as `prerelease` in semver specification. meaning that the versions comparison is `1.3.1 > 1.3.1-zendesk` that would be used in fuzzy version matching. this is not problem for us since we intend to use it with explicit version.

there is no good recomendation in semver how to handle this. they either recommend to rename the package itself (if the fork is never meant to be merged into upstream), or they assume since fork is not public there is no need to version it.